### PR TITLE
add init height in node status

### DIFF
--- a/protos/common.proto
+++ b/protos/common.proto
@@ -109,4 +109,5 @@ message NodeStatus {
     uint64 peers_count = 4;
     repeated PeerStatus peers_status = 5;
     bool is_danger = 6;
+    uint64 init_block_number = 7;
 }


### PR DESCRIPTION
效果
```
 2023-03-16T04:10:16.788164686-04:00  INFO controller: controller grpc port: 50004                                                                                                                                                                                                          │
│ 2023-03-16T04:10:16.788192804-04:00  INFO controller: health check timeout: 300                                                                                                                                                                                                            │
│ 2023-03-16T04:10:16.790670721-04:00  INFO controller: network service ready                                                                                                                                                                                                                │
│ 2023-03-16T04:10:17.053690453-04:00  INFO controller: crypto_sm service ready                                                                                                                                                                                                              │
│ 2023-03-16T04:10:17.053733133-04:00  INFO controller: load system config                                                                                                                                                                                                                   │
│ 2023-03-16T04:10:17.055978845-04:00  INFO controller: storage service ready, get current height success                                                                                                                                                                                    │
│ 2023-03-16T04:10:17.056004206-04:00  INFO controller: this is an old chain                                                                                                                                                                                                                 │
│ 2023-03-16T04:10:17.056378212-04:00  INFO controller: init height: 6384, init block hash: 0xbaa647643b07aa6919ab041dc4e114ae65b48a12d6a291629a390c726aa4bc02 
```
```
cldi> get node-status
{
  "init_block_number": 6384,
。。。
  "self_status": {
    "address": "0x34170630731bc858022867035b564d632645f212",
    "height": 6423
  },
  "version": "6.6.4"
}
```